### PR TITLE
Slp converter

### DIFF
--- a/eks/core.py
+++ b/eks/core.py
@@ -5,6 +5,7 @@ from matplotlib import pyplot as plt
 from jax import jit, vmap
 import jax.scipy as jsc
 from functools import partial
+from jax.lax import associative_scan, psum, scan
 
 
 def ensemble(markers_list, keys, mode='median'):
@@ -394,6 +395,147 @@ def compute_initial_guesses(ensemble_vars):
 # --------------------------------------------------------------------
 
 
+def first_filtering_element(C, A, Q, R, m0, P0, y):
+    # model.F = A, model.H = C,
+    S = C @ Q @ C.T + R
+    CF, low = jsc.linalg.cho_factor(S)  # note the jsc
+
+    m1 = A @ m0
+    P1 = A @ P0 @ A.T + Q
+    S1 = C @ P1 @ C.T + R
+    K1 = jsc.linalg.solve(S1, C @ P1, assume_a='pos').T  # note the jsc
+
+    A_updated = jnp.zeros_like(A)
+    b = m1 + K1 @ (y - C @ m1)
+    C_updated = P1 - K1 @ S1 @ K1.T
+
+    # note the jsc
+    eta = A.T @ C.T @ jsc.linalg.cho_solve((CF, low), y)
+    J = A.T @ C.T @ jsc.linalg.cho_solve((CF, low), C @ A)
+    return A_updated, b, C_updated, J, eta
+
+
+def generic_filtering_element(C, A, Q, R, y):
+    S = C @ Q @ C.T + R
+    CF, low = jsc.linalg.cho_factor(S)  # note the jsc
+    K = jsc.linalg.cho_solve((CF, low), C @ Q).T  # note the jsc
+    A_updated = A - K @ C @ A 
+    b = K @ y
+    C_updated = Q - K @ C @ Q
+
+    # note the jsc
+    eta = A.T @ C.T @ jsc.linalg.cho_solve((CF, low), y)
+    J = A.T @ C.T @ jsc.linalg.cho_solve((CF, low), C @ A)
+    return A_updated, b, C_updated, J, eta
+    
+def make_associative_filtering_elements(C, A, Q, R, m0, P0, observations):
+    first_elems = first_filtering_element(C, A, Q, R, m0, P0, observations[0])
+    generic_elems = vmap(lambda o: generic_filtering_element(C, A, Q, R, o))(observations[1:])
+    return tuple(jnp.concatenate([jnp.expand_dims(first_e, 0), gen_es]) 
+                 for first_e, gen_es in zip(first_elems, generic_elems))
+
+@partial(vmap)
+def filtering_operator(elem1, elem2):
+    # # note the jsc everywhere
+    A1, b1, C1, J1, eta1 = elem1
+    A2, b2, C2, J2, eta2 = elem2
+    dim = A1.shape[0]
+    I = jnp.eye(dim)  # note the jnp
+
+    I_C1J2 = I + C1 @ J2
+    temp = jsc.linalg.solve(I_C1J2.T, A2.T).T
+    A = temp @ A1
+    b = temp @ (b1 + C1 @ eta2) + b2
+    C = temp @ C1 @ A2.T + C2
+
+    I_J2C1 = I + J2 @ C1
+    temp = jsc.linalg.solve(I_J2C1.T, A1).T
+
+    eta = temp @ (eta2 - J2 @ b1) + eta1
+    J = temp @ J2 @ A1 + J1
+
+    return A, b, C, J, eta
+
+
+def pkf(y, m0, cov0, A, Q, C, R):
+    initial_elements = make_associative_filtering_elements(C, A, Q, R, m0, cov0, y)
+    final_elements = associative_scan(filtering_operator, initial_elements)
+    return final_elements
+    
+pkf_func = jit(pkf)
+
+
+def get_kalman_means(A_scan, b_scan, m0):
+    """
+    Computes the Kalman mean at a single timepoint, the result is: 
+    A_scan @ m0 + b_scan
+
+    Returned shape: (state_dimension, 1)
+    """
+    return A_scan @ jnp.expand_dims(m0, axis = 1) + jnp.expand_dims(b_scan, axis = 1)
+
+def get_kalman_variances(C):
+    return C
+
+def get_next_cov(A, C, Q, R, filter_cov, filter_mean):
+    """
+    Given the moments of p(x_t | y_1, ..., y_t) (normal filter distribution), compute the moments of the distribution for: 
+    p(y_{t+1} | y_1, ..., y_t)
+
+    Params: 
+        A (np.ndarray): Shape (state_dimension, state_dimension) Process coeff matrix
+        C (np.ndarray): Shape (obs_dimension, state_dimension) Observation coeff matrix
+        Q (np.ndarray): Shape (state_dimension, state_dimension). Process noise covariance matrix. 
+        R (np.ndarray): Shape (obs_dimension, obs_dimension). Observation noise covariance matrix. 
+        filter_cov (np.ndarray). Shape (state_dimension, state_dimension). Filtered covariance
+        filter_mean (np.ndarray). Shape (state_dimension, 1). Filter mean 
+
+    Returns: 
+        mean (np.ndarray). Shape (obs_dimension, 1)
+        cov (np.ndarray). Shape (obs_dimension, obs_dimension). 
+    """
+    mean = C @ A @ filter_mean
+    cov = C @ (A @ filter_cov @ A.T + Q) @ C.T + R
+    return mean, cov
+
+def compute_marginal_nll(value, mean, covariance):
+    return -1*jax.scipy.stats.multivariate_normal.logpdf(value, mean, covariance)
+
+def parallel_loss_single(A_scan, b_scan, C_scan, A, C, Q, R, next_observation, m0):
+    curr_mean = get_kalman_means(A_scan, b_scan, m0)
+    curr_cov = get_kalman_variances(C_scan) #Placeholder; just returns identity
+
+    next_mean, next_cov = get_next_cov(A, C, Q, R, curr_cov, curr_mean)
+    return jnp.squeeze(curr_mean), curr_cov, compute_marginal_nll(jnp.squeeze(next_observation), jnp.squeeze(next_mean), next_cov)
+
+parallel_loss_func_vmap = vmap(parallel_loss_single, in_axes = (0, 0, 0, None, None, None, None, 0, None), out_axes = (0, 0, 0))
+
+@partial(jit)
+def y1_given_x0_nll(C, A, Q, R, m0, cov0, obs):
+    y1_predictive_mean = C @ A @ jnp.expand_dims(m0, axis = 1)
+    y1_predictive_cov = C @ (A @ cov0 @ A.T + Q) @ C.T + R
+    addend = -1*jax.scipy.stats.multivariate_normal.logpdf(obs, jnp.squeeze(y1_predictive_mean), y1_predictive_cov)
+    return addend
+    
+
+def pkf_and_loss(y, m0, cov0, A, Q, C, R):
+    A_scan, b_scan, C_scan, _, _ = pkf_func(y, m0, cov0, A, Q, C, R)
+
+    #Gives us the NLL for p(y_i | y_1, ..., y_{i-1}) for i > 1. Need to use the parallel scan outputs for this. i = 1 handled below
+    filtered_states, filtered_covariances, losses = parallel_loss_func_vmap(A_scan[:-1], b_scan[:-1], C_scan[:-1], A, C, Q, R, y[1:], m0)
+    
+
+    #Gives us the NLL for p_y(y_1 | x_0)
+    addend = y1_given_x0_nll(C, A, Q, R, m0, cov0, y[0])
+    
+    final_mean = get_kalman_means(A_scan[-1], b_scan[-1], m0).T
+    final_covariance = jnp.expand_dims(get_kalman_variances(C_scan[-1]), axis = 0)
+    filtered_states = jnp.concatenate([filtered_states, final_mean], axis = 0)
+    filtered_variances = jnp.concatenate([filtered_covariances, final_covariance], axis = 0)
+    return filtered_states, filtered_variances, losses + addend
+
+
+
 def kalman_filter_step(carry, curr_y):
     m_prev, V_prev, A, Q, C, R, nll_net = carry
 
@@ -412,6 +554,9 @@ def kalman_filter_step(carry, curr_y):
     nll_net = nll_net + nll_current
 
     return (m_t, V_t, A, Q, C, R, nll_net), (m_t, V_t, nll_current)
+
+
+    
 
 #Always run the sequential filter on CPU because the GPU will deploy individual kernels for each scan iteration, very slow. 
 @partial(jit, backend='cpu')

--- a/eks/core.py
+++ b/eks/core.py
@@ -508,7 +508,7 @@ def parallel_loss_single(A_scan, b_scan, C_scan, A, C, Q, R, next_observation, m
     next_mean, next_cov = get_next_cov(A, C, Q, R, curr_cov, curr_mean)
     return jnp.squeeze(curr_mean), curr_cov, compute_marginal_nll(jnp.squeeze(next_observation), jnp.squeeze(next_mean), next_cov)
 
-parallel_loss_func_vmap = vmap(parallel_loss_single, in_axes = (0, 0, 0, None, None, None, None, 0, None), out_axes = (0, 0, 0))
+parallel_loss_func_vmap = jit(vmap(parallel_loss_single, in_axes = (0, 0, 0, None, None, None, None, 0, None), out_axes = (0, 0, 0)))
 
 @partial(jit)
 def y1_given_x0_nll(C, A, Q, R, m0, cov0, obs):
@@ -532,7 +532,7 @@ def pkf_and_loss(y, m0, cov0, A, Q, C, R):
     final_covariance = jnp.expand_dims(get_kalman_variances(C_scan[-1]), axis = 0)
     filtered_states = jnp.concatenate([filtered_states, final_mean], axis = 0)
     filtered_variances = jnp.concatenate([filtered_covariances, final_covariance], axis = 0)
-    return filtered_states, filtered_variances, losses + addend
+    return filtered_states, filtered_variances, jnp.sum(losses) + addend
 
 
 

--- a/eks/utils.py
+++ b/eks/utils.py
@@ -190,10 +190,11 @@ def populate_output_dataframe(keypoint_df, keypoint_ensemble, output_df,
 
 def plot_results(output_df, input_dfs_list,
                  key, s_final, nll_values, idxs, save_dir, smoother_type):
-    # crop NLL values
-    nll_values_subset = nll_values[idxs[0]:idxs[1]]
-
-    fig, axes = plt.subplots(5, 1, figsize=(9, 10))
+    
+    if nll_values is None:
+        fig, axes = plt.subplots(4, 1, figsize=(9, 10))
+    else:
+        fig, axes = plt.subplots(5, 1)
 
     for ax, coord in zip(axes, ['x', 'y', 'likelihood', 'zscore']):
         # Rename axes label for likelihood and zscore coordinates
@@ -227,8 +228,10 @@ def plot_results(output_df, input_dfs_list,
             ax.legend()
 
         # Plot nll_values against the time axis
-        axes[-1].plot(range(*idxs), nll_values_subset, color='k', linewidth=2)
-        axes[-1].set_ylabel('EKS NLL', fontsize=12)
+        if nll_values is not None:
+            nll_values_subset = nll_values[idxs[0]:idxs[1]]
+            axes[-1].plot(range(*idxs), nll_values_subset, color='k', linewidth=2)
+            axes[-1].set_ylabel('EKS NLL', fontsize=12)
 
     plt.suptitle(f'EKS results for {key}, smoothing = {s_final}', fontsize=14)
     plt.tight_layout()

--- a/scripts/singlecam_example.py
+++ b/scripts/singlecam_example.py
@@ -17,10 +17,7 @@ bodypart_list = args.bodypart_list
 s = args.s  # defaults to automatic optimization
 s_frames = args.s_frames  # frames to be used for automatic optimization (only if no --s flag)
 blocks = args.blocks
-use_optax = False
-if args.optax == "True":
-    use_optax = True
-    print("Using Optax")
+
 
 # Load and format input files and prepare an empty DataFrame for output.
 input_dfs, output_df, keypoint_names = format_data(args.input_dir, data_type)
@@ -45,13 +42,12 @@ key_cols = np.array(keys)
 markers_3d_array = markers_3d_array[:, :, key_cols]
 
 # Call the smoother function
-df_dicts, s_finals, nll_values_array = ensemble_kalman_smoother_singlecam(
+df_dicts, s_finals = ensemble_kalman_smoother_singlecam(
     markers_3d_array,
     bodypart_list,
     s,
     s_frames,
-    blocks,
-    use_optax
+    blocks
 )
 
 keypoint_i = -1  # keypoint to be plotted
@@ -68,7 +64,7 @@ plot_results(output_df=output_df,
              key=f'{bodypart_list[keypoint_i]}',
              idxs=(0, 500),
              s_final=s_finals[keypoint_i],
-             nll_values=nll_values_array[keypoint_i],
+             nll_values=None,
              save_dir=save_dir,
              smoother_type=smoother_type
              )


### PR DESCRIPTION
Key changes: 
- Fixes bug with smoother code
- On CPU, provides an updated jax.lax.scan implementation that can do filtering on blocks of keypoints, parallelized at all stages (over keypoints, over time points, etc.)
- Includes a GPU parallel scan implementation for the Kalman filter -- again fully "jitted". This is used to do parameter estimation for the smoothing parameter. Code computes the Kalman filter + nonnegative log likelihood very fast. 
- Optax (jax) optimizer differentiates through all of the above implementations, allowing fast MLE computation of the smoothing parameter. Note: Can in principle also compute the observation noise data with minor modifications. 