### PR TITLE
restrict FA fitting in maha distance to low variance observations

### DIFF
--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -8,11 +8,11 @@ def test_compute_mahalanobis():
     np.random.seed(0)
 
     # simple test on output shapes
-    n_t = 10
+    n_t = 100
     n_cams = 6
     x = np.random.randn(n_t, 2 * n_cams)
-    v = np.ones((n_t, 2 * n_cams))
-    out = compute_mahalanobis(x=x, v=v, n_latent=3)
+    v = np.ones(x.shape)
+    out = compute_mahalanobis(x=x, v=v, n_latent=3, v_quantile_threshold=None)
 
     assert 'mahalanobis' in out.keys()
     assert len(out['mahalanobis']) == n_cams
@@ -25,7 +25,25 @@ def test_compute_mahalanobis():
     assert 'reconstructed' in out.keys()
     assert out['reconstructed'].shape == x.shape
 
-    # test actual data: is data reconstructed with the true number of latents?
+    # simple test with likelihoods
+    likes = np.random.rand(n_t, n_cams)
+    out = compute_mahalanobis(
+        x=x, v=v, n_latent=3, likelihoods=likes,
+        likelihood_threshold=0.1,
+        v_quantile_threshold=None,
+    )
+    assert out['mahalanobis'][0].shape == (n_t, 1)
+    assert out['posterior_variance'][0].shape == (n_t, 2, 2)
+    assert out['reconstructed'].shape == x.shape
+
+    # simple test with ensemble variances
+    v = 0.01 * np.random.randn(*x.shape) + np.ones(x.shape)
+    out = compute_mahalanobis(x=x, v=v, n_latent=3, likelihoods=None, v_quantile_threshold=50)
+    assert out['mahalanobis'][0].shape == (n_t, 1)
+    assert out['posterior_variance'][0].shape == (n_t, 2, 2)
+    assert out['reconstructed'].shape == x.shape
+
+    # test actual data
     n_t = 100
     n_latent = 3
     n_cams = 6
@@ -34,13 +52,15 @@ def test_compute_mahalanobis():
     x = z @ W.T
     v = np.ones((n_t, 2 * n_cams))
 
-    out = compute_mahalanobis(x, v, n_latent=n_latent)
+    # is data reconstructed with the *true* number of latents?
+    out = compute_mahalanobis(x, v, n_latent=n_latent, v_quantile_threshold=None)
     assert np.allclose(x, out['reconstructed'])
 
-    out = compute_mahalanobis(x, v, n_latent=1)
+    # is data *not* reconstructed with the smaller number of latents?
+    out = compute_mahalanobis(x, v, n_latent=1, v_quantile_threshold=None)
     assert not np.allclose(x, out['reconstructed'])
 
-    # test actual data: is the maha smaller/posterior variance larger when observed var is larger?
+    # is the maha smaller/posterior variance larger when observed var is larger?
     s = 10  # scale up ens var
     x2 = np.vstack([x, x])
     v2 = np.vstack([np.ones((n_t, 2 * n_cams)), s * np.ones((n_t, 2 * n_cams))])


### PR DESCRIPTION
FA was being fit on all observations (if not using likelihood thresholding), including high-variance observations. The changes in this PR add an additional threshold for filtering out high-variance observations before learning the linear latent variable model with FA. All subsequent computations of maha distance (and reconstructions, and posterior predictive variances) are performed on *all* observations.

Closes #34 