### PR TITLE
use pca_object to subtract means when present

### DIFF
--- a/eks/multicam_smoother.py
+++ b/eks/multicam_smoother.py
@@ -507,6 +507,7 @@ def mA_compute_maha(
     centered_emA_preds: MarkerArray,
     emA_vars: MarkerArray,
     emA_likes: MarkerArray,
+    n_latent,
     inflate_vars_kwargs: dict = {},
     threshold: float = 5,
     scalar: float = 2

--- a/eks/stats.py
+++ b/eks/stats.py
@@ -6,11 +6,11 @@ from eks.marker_array import MarkerArray, mA_to_stacked_array
 
 
 def compute_pca(
-        valid_frames_mask,
-        emA_centered_preds: MarkerArray,
-        emA_good_centered_preds: MarkerArray,
-        n_components: int = 3,
-        pca_object: PCA | None = None
+    valid_frames_mask,
+    emA_centered_preds: MarkerArray,
+    emA_good_centered_preds: MarkerArray,
+    n_components: int = 3,
+    pca_object: PCA | None = None
 ):
     """
     Performs Principal Component Analysis (PCA) per keypoint using filtered + centered predictions.
@@ -31,7 +31,7 @@ def compute_pca(
             good_pcs_list (list): List of PCA-transformed coordinates for variance-filtered frames.
     """
     n_models, n_cameras, n_frames, n_keypoints, _ = emA_centered_preds.shape
-    assert n_models == 1, "MarkerArray should have n_models = 1 after ensembling."
+    assert n_models == 1, "MarkerArray should have n_models = 1 when computing PCA."
 
     ensemble_pca = []
     good_pcs_list = []
@@ -43,14 +43,13 @@ def compute_pca(
         emA_good_centered_preds_k = emA_good_centered_preds.slice("keypoints", k)
 
         # Reshape good_centered_preds_k and centered_preds_k for PCA
-        reshaped_gsp_k = mA_to_stacked_array(emA_good_centered_preds_k, 0)
+        reshaped_gcp_k = mA_to_stacked_array(emA_good_centered_preds_k, 0)
         reshaped_sp_k = mA_to_stacked_array(emA_centered_preds_k, 0)
-
 
         # Fit PCA per keypoint
         if pca_object is None:
             pca = PCA(n_components=n_components)
-            ensemble_pca_k = pca.fit(reshaped_gsp_k)
+            ensemble_pca_k = pca.fit(reshaped_gcp_k)
         else:
             ensemble_pca_k = pca_object
         # Transform full dataset

--- a/tests/test_multicam_smoother.py
+++ b/tests/test_multicam_smoother.py
@@ -139,6 +139,28 @@ def test_ensemble_kalman_smoother_multicam():
         mask = df.columns.get_level_values("coords").isin(["x_ens_var", "y_ens_var"])
         assert np.allclose(df.iloc[:, mask], 0, atol=1e-4), "should have zero ensemble variance"
 
+    # ---------------------------------------------------
+    # Run with no variance inflation but use PCA object
+    # ---------------------------------------------------
+    camera_dfs, smooth_params_final = ensemble_kalman_smoother_multicam(
+        marker_array=marker_array,
+        keypoint_names=keypoint_names,
+        smooth_param=smooth_param,
+        quantile_keep_pca=quantile_keep_pca,
+        camera_names=camera_names,
+        s_frames=s_frames,
+        inflate_vars=False,
+        pca_object=pca,
+    )
+    assert isinstance(camera_dfs, list), "Expected output to be a list"
+    assert len(camera_dfs) == len(camera_names), \
+        f"Expected {len(camera_names)} entries in camera_dfs, got {len(camera_dfs)}"
+    assert isinstance(smooth_params_final, float), \
+        f"Expected smooth_param_final to be a float, got {type(smooth_params_final)}"
+    assert smooth_params_final == smooth_param, \
+        f"Expected smooth_param_final to match input smooth_param ({smooth_param}), " \
+        f"got {smooth_params_final}"
+
 
 def test_ensemble_kalman_smoother_multicam_no_smooth_param():
     """Test ensemble_kalman_smoother_multicam with no smooth_param provided."""


### PR DESCRIPTION
EDIT: closing this PR as using the pca_object to subtract means does *not* work, specifically with cropped datasets where PCA is fit globally on uncropped data but then EKS is run on a snippet with a different mean value; this will lead to non-zero mean data being fed into EKS, which it is not equipped to  handle in the current implementation.