### PR TITLE
expand test matrix to Python 3.10–3.12 and Ubuntu/macOS

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - name: Check out code
@@ -20,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
@@ -32,6 +36,7 @@ jobs:
           pytest --cov --cov-branch --cov-report=xml
 
       - name: Upload coverage reports to Codecov
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "ensemble-kalman-smoother"
-version = "4.6.1"
+version = "4.6.2"
 description = "Ensembling and kalman smoothing for pose estimation"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
  Extends the test workflow from a single ubuntu-latest + Python 3.10 job to a 2×3 matrix
  (ubuntu-latest/macos-latest × Python 3.10/3.11/3.12), giving coverage across supported Python versions
  and confirming macOS compatibility. Codecov upload is restricted to the ubuntu-latest + 3.10 leg to avoid
  duplicate/conflicting coverage reports.